### PR TITLE
Improve parse_type UnknownImageType detection

### DIFF
--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -301,7 +301,7 @@ class FastImage
   end
 
   def parse_type
-    type = case @stream.peek(2)
+    parsed_type = case @stream.peek(2)
     when "BM"
       :bmp
     when "GI"
@@ -327,7 +327,7 @@ class FastImage
       :svg if @stream.peek(64).include?("<svg")
     end
         
-    type or raise UnknownImageType
+    parsed_type or raise UnknownImageType
   end
 
   def parse_size_for_ico

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -327,7 +327,7 @@ class FastImage
       :svg if @stream.peek(64).include?("<svg")
     end
         
-    type || raise UnknownImageType
+    type or raise UnknownImageType
   end
 
   def parse_size_for_ico

--- a/lib/fastimage.rb
+++ b/lib/fastimage.rb
@@ -301,7 +301,7 @@ class FastImage
   end
 
   def parse_type
-    case @stream.peek(2)
+    type = case @stream.peek(2)
     when "BM"
       :bmp
     when "GI"
@@ -321,21 +321,13 @@ class FastImage
       when 2 then :cur
       end
     when "RI"
-      if @stream.peek(12)[8..11] == "WEBP"
-        :webp
-      else
-        raise UnknownImageType
-      end
+      :webp if @stream.peek(12)[8..11] == "WEBP"
     when "<s", "<?"
       # Does not handle UTF-16 or other multi-byte encodings
-      if @stream.peek(64).include?("<svg")
-        :svg
-      else
-        raise UnknownImageType
-      end
-    else
-      raise UnknownImageType
+      :svg if @stream.peek(64).include?("<svg")
     end
+        
+    type || raise UnknownImageType
   end
 
   def parse_size_for_ico


### PR DESCRIPTION
In case of 'ice' a default value should raise `UnknownImageType` but it didn't, probably due to the code not being 100% DRY.

This commit fixes both issues at once
